### PR TITLE
Refactor CLI for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <br>
 
   ![Language](https://img.shields.io/badge/-python-3776AB.svg?style=for-the-badge&logo=python&logoColor=white)
-  
+
   <a href="https://github.com/demonkingswarn/flix-cli"><img src="https://img.shields.io/github/stars/demonkingswarn/flix-cli?color=orange&logo=github&style=flat-square " alt="starcount"></a> <a href="https://pypi.org/project/flix-cli/" ><img src="https://img.shields.io/pypi/dm/flix-cli" alt="pypi downloads" /></a>
 
   <a href="http://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
@@ -153,11 +153,51 @@ pip install --upgrade flix-cli
 # Usage
 
 ```sh
-Usage: flix-cli [ARGS]...
+Usage: flix-cli [OPTIONS] [QUERY]...
+```
 
-Options:
-    download    Download your favourite movie by query.
-    play        Stream your favourite movie by query.
+`QUERY` is the title you want to search for (e.g., `breaking bad`, `dune`, `oppenheimer`).
+
+### **Options**
+
+| Option | Alias | Description |
+| --- | --- | --- |
+| `--action <play\|download\|cast>` | `-a` | Choose whether to **play**, **download**, or **cast** the selected media. Defaults to `play`. |
+| `--season <number>`  | `-s` | (Series only) Specify a **season** number. |
+| `--episodes <range>` | `-e` | (Series only) Specify a **single episode** (`5`) or a **range** (`3-7`). |
+| `--help` |  | Show help message and exit. |
+
+
+## 🎬 Examples
+
+### **Search & Play a Movie**
+
+```sh
+flix-cli dune
+```
+
+### **Download a Movie**
+
+```sh
+flix-cli dune --action download
+```
+
+### **Play a TV Episode**
+
+```sh
+flix-cli "breaking bad" --season 1 --episodes 1
+```
+
+### **Play a Range of Episodes**
+
+```sh
+flix-cli "the office" -s 3 -e 5-10
+```
+
+### **Chromecast Playback**
+
+```sh
+flix-cli avatar -a cast
 ```
 
 # Configuration
@@ -186,12 +226,11 @@ If you run into issues or want to request a new feature, you are encouraged to m
 # Project Disclaimer
 The disclaimer of the project  can be found <a href="https://github.com/demonkingswarn/flix-cli/blob/master/disclaimer.org">here</a>.
 
-
-## Star History 
+## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=demonkingswarn/flix-cli&type=date&legend=top-left)](https://www.star-history.com/#demonkingswarn/flix-cli&type=date&legend=top-left)
 
-## Contributing 
+## Contributing
 Pull requests are welcome and *appreciated*. For major changes, please open an issue first to discuss what you would like to change.
 
 <a href = "https://github.com/demonkingswarn/flix-cli/graphs/contributors">
@@ -204,4 +243,3 @@ Pull requests are welcome and *appreciated*. For major changes, please open an i
 - [`ani-cli`](https://github.com/pystardust/ani-cli): A cli tool to browse and play anime. (Shell)
 - [`mov-cli`](https://github.com/mov-cli/mov-cli): [WIP] watch movies and webseries from the cli. (Python/Shell)
 - [`kami`](https://github.com/mrfluffy-dev/kami): Read light novels and watch anime in your terminal. (Rust)
- 

--- a/flix_cli/__main__.py
+++ b/flix_cli/__main__.py
@@ -1,9 +1,4 @@
 from .core import __flix_cli__
 
-
-def __flixcli__():
-    __flix_cli__
-
-
 if __name__ == "__main__":
-    __flixcli__()
+    __flix_cli__.app()

--- a/flix_cli/core/__flix_cli__.py
+++ b/flix_cli/core/__flix_cli__.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
 
-import os
-import platform
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+# ruff: noqa: UP035 - allow using typing.List
+from typing import Annotated, List, Optional, Self, overload
+from urllib.parse import urljoin
 
 import httpx
 import regex as re
+import typer
+from bs4 import BeautifulSoup
 from fzf import fzf_prompt
+from platformdirs import user_downloads_path
 
 from .__version__ import __core__
 from .utils.__cast__ import cast
@@ -13,57 +22,89 @@ from .utils.__decryptor__ import decrypt_stream_url
 from .utils.__downloader__ import download
 from .utils.__player__ import play
 
-try:
-    import orjson as json  # noqa: F401
-except ImportError:
-    pass
-
-import sys
-from urllib.parse import urljoin
-
-from bs4 import BeautifulSoup
-
-headers = {
-    "User-Agent": f"flix-cli/{__core__}",
-    "Referer": "https://flixhq.to/",
-    "X-Requested-With": "XMLHttpRequest",
-}
-
-client = httpx.Client(headers=headers, follow_redirects=True, timeout=None)
-
 FLIXHQ_BASE_URL = "https://flixhq.to"
 FLIXHQ_SEARCH_URL = f"{FLIXHQ_BASE_URL}/search"
 FLIXHQ_AJAX_URL = f"{FLIXHQ_BASE_URL}/ajax"
 DECODER = "https://dec.eatmynerds.live"
 
-selected_media = None
-selected_subtitles = []
+
+class Action(str, Enum):
+    PLAY = "play"
+    DOWNLOAD = "download"
+    CAST = "cast"
 
 
-def parse_episode_range(episode_input: str) -> list[int] | None:
-    """Parse episode input to handle ranges like '5-7' or single episodes like '5'"""
-    episode_input = episode_input.strip()
-    if "-" in episode_input:
+class MediaType(str, Enum):
+    MOVIE = "movie"
+    SERIES = "series"
+
+
+class EpisodeRange(Sequence[int]):
+    def __init__(self, ep_range: range) -> None:
+        self.range = ep_range
+
+    @classmethod
+    def from_str(cls, ep_input: str) -> Self:
+        """Parse episode input to handle ranges like '5-7' or single episodes like '5'"""
+        ep_input = ep_input.strip()
+
         try:
-            start, end = episode_input.split("-", 1)
-            start_ep = int(start.strip())
-            end_ep = int(end.strip())
-            if start_ep > end_ep:
-                raise ValueError("Start episode cannot be greater than end episode")
-            return list(range(start_ep, end_ep + 1))
-        except ValueError as e:
-            print(f"Invalid episode range format: {e}")
-            return None
-    else:
-        try:
-            single_ep = int(episode_input)
-            return [single_ep]
+            if "-" in ep_input:
+                start, end = ep_input.split("-", 1)
+                start_ep = int(start.strip())
+                end_ep = int(end.strip())
+
+                if start_ep > end_ep:
+                    start_ep, end_ep = end_ep, start_ep
+
+                return cls(range(start_ep, end_ep + 1))
+            else:
+                ep = int(ep_input)
+                return cls(range(ep, ep + 1))
+
         except ValueError:
-            print("Invalid episode number")
-            return None
+            raise typer.BadParameter(
+                "Invalid episode/range, input must be a number or range in the form <num>-<num>"
+            )
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.range)
+
+    def __len__(self) -> int:
+        return len(self.range)
+
+    @overload
+    def __getitem__(self, i: int) -> int: ...
+
+    @overload
+    def __getitem__(self, i: slice) -> Self: ...
+
+    def __getitem__(self, i: int | slice) -> int | Self:
+        if isinstance(i, slice):
+            return self.__class__(self.range[i])
+        return self.range[i]
 
 
-def search_content(query: str):
+@dataclass
+class Context:
+    client: httpx.Client
+
+    query: str | None = None
+    url: str | None = None
+    title: str | None = None
+    content_type: MediaType | None = None
+
+    season: int | None = None
+    episodes: EpisodeRange | None = None
+
+    selected_media: list[dict[str, str | int | None]] | None = None
+    selected_subtitles: list[str] = field(default_factory=list)
+
+    dl_path: Path = user_downloads_path()
+    play_type: Action | None = None
+
+
+def search_content(query: str, client: httpx.Client):
     """Search for content on flixhq.to"""
     try:
         search_params = query.replace(" ", "-")
@@ -71,11 +112,12 @@ def search_content(query: str):
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
         items = soup.find_all("div", class_="flw-item")
+
         if not items:
-            print("No results found")
-            return None
-        results = []
-        urls = []
+            raise RuntimeError("No results found for query")
+
+        results: list[str] = []
+        urls: list[str] = []
         for i, item in enumerate(items[:10]):
             poster_link = item.find("div", class_="film-poster")
             detail_section = item.find("div", class_="film-detail")
@@ -104,20 +146,24 @@ def search_content(query: str):
                         display_title += f" [{content_type}]"
                     results.append(display_title)
                     urls.append(urljoin(FLIXHQ_BASE_URL, href))
+
         if not results:
-            print("No valid results found")
-            return None
+            raise RuntimeError("No results found for query")
+
         selected = fzf_prompt(results)
         if not selected:
-            return None
+            print("No media selected, exiting")
+            exit(0)
+
         selected_index = int(selected[0]) - 1
-        return urls[selected_index]
+        return urls[selected_index], results[selected_index].partition(". ")[-1]
+
     except Exception as e:
-        print(f"Search failed: {e}")
-        return None
+        err_msg = f"Search failed: {e}"
+        raise RuntimeError(err_msg)
 
 
-def get_tv_seasons(media_id: str):
+def get_tv_seasons(media_id: str, client: httpx.Client) -> list[dict[str, str]]:
     try:
         seasons_url = f"{FLIXHQ_AJAX_URL}/v2/tv/seasons/{media_id}"
         response = client.get(seasons_url)
@@ -134,7 +180,7 @@ def get_tv_seasons(media_id: str):
         return []
 
 
-def get_season_episodes(season_id: str):
+def get_season_episodes(season_id: str, client: httpx.Client):
     try:
         episodes_url = f"{FLIXHQ_AJAX_URL}/v2/season/episodes/{season_id}"
         response = client.get(episodes_url)
@@ -154,7 +200,7 @@ def get_season_episodes(season_id: str):
         return []
 
 
-def get_episode_servers(data_id: str, preferred_provider: str = "Vidcloud"):
+def get_episode_servers(data_id: str, client: httpx.Client, preferred_provider: str = "Vidcloud"):
     try:
         servers_url = f"{FLIXHQ_AJAX_URL}/v2/episode/servers/{data_id}"
         response = client.get(servers_url)
@@ -178,7 +224,7 @@ def get_episode_servers(data_id: str, preferred_provider: str = "Vidcloud"):
         return None
 
 
-def get_embed_link(episode_id: str):
+def get_embed_link(episode_id: str, client: httpx.Client) -> str | None:
     try:
         sources_url = f"{FLIXHQ_AJAX_URL}/episode/sources/{episode_id}"
         response = client.get(sources_url)
@@ -193,16 +239,21 @@ def get_embed_link(episode_id: str):
         return None
 
 
-def get_episode_data(target_episode, season_num, episode_num):
+def get_episode_data(
+    target_episode, season_num: int, episode_num: int, client: httpx.Client
+) -> dict[str, str | int | None] | None:
     """Get stream data for a single episode"""
-    episode_id = get_episode_servers(target_episode["data_id"], "Vidcloud")
-    if not episode_id:
+
+    episode_id = get_episode_servers(target_episode["data_id"], client, "Vidcloud")
+    if episode_id is None:
         print(f"Warning: Could not get server ID for episode {episode_num}")
         return None
-    embed_link = get_embed_link(episode_id)
-    if not embed_link:
+
+    embed_link = get_embed_link(episode_id, client)
+    if embed_link is None:
         print(f"Warning: Could not get embed link for episode {episode_num}")
         return None
+
     return {
         "file": embed_link,
         "label": f"S{season_num}E{episode_num} - {target_episode['title']}",
@@ -212,172 +263,169 @@ def get_episode_data(target_episode, season_num, episode_num):
     }
 
 
-def movie():
+def movie(ctx: Context):
     """Handle movie streaming"""
-    global selected_media, selected_subtitles
-    media_id_match = re.search(r"/movie/[^/]*-(\d+)", get_id.selected_url)
+    assert ctx.url is not None
+    media_id_match = re.search(r"/movie/[^/]*-(\d+)", ctx.url)
     if not media_id_match:
         raise RuntimeError("Could not extract media ID from URL")
     media_id = media_id_match.group(1)
+
     try:
         movie_episodes_url = f"{FLIXHQ_AJAX_URL}/movie/episodes/{media_id}"
-        response = client.get(movie_episodes_url)
-        if response.status_code == 200:
-            content = response.text.replace("\n", "").replace(
-                'class="nav-item"', '\nclass="nav-item"'
-            )
-            provider_pattern = re.compile(r'href="([^"]*)"[^>]*title="Vidcloud"')
-            match = provider_pattern.search(content)
-            if match:
-                movie_page_url = FLIXHQ_BASE_URL + match.group(1)
-                episode_match = re.search(r"-(\d+)\.(\d+)$", movie_page_url)
-                if episode_match:
-                    episode_id = episode_match.group(2)
-                    embed_link = get_embed_link(episode_id)
-                    if embed_link:
-                        selected_media = [
-                            {"file": embed_link, "label": "Movie Stream", "type": "embed"}
-                        ]
-                        selected_subtitles = []
-                        return
+        response = ctx.client.get(movie_episodes_url)
+
+        if response.status_code != 200:
+            raise RuntimeError("Failed to get media url from server")
+
+        content = response.text.replace("\n", "").replace('class="nav-item"', '\nclass="nav-item"')
+
+        provider_pattern = re.compile(r'href="([^"]*)"[^>]*title="Vidcloud"')
+        provider_match = provider_pattern.search(content)
+
+        if not provider_match:
+            raise RuntimeError("Failed to find provider for media")
+
+        movie_page_url = FLIXHQ_BASE_URL + provider_match.group(1)
+        episode_match = re.search(r"-(\d+)\.(\d+)$", movie_page_url)
+
+        if not episode_match:
+            raise RuntimeError("Failed to find provider for media")
+
+        episode_id = episode_match.group(2)
+        embed_link = get_embed_link(episode_id, ctx.client)
+
+        if not embed_link:
+            raise RuntimeError("Failed to find provider for media")
+
+        ctx.selected_media = [{"file": embed_link, "label": ctx.query, "type": "embed"}]
+        ctx.selected_subtitles = []
+        return
+
     except Exception as e:
         print(f"Movie processing failed: {e}")
-    raise RuntimeError("Could not get movie stream")
+        exit(1)
 
 
-def series():
+def series(ctx: Context):
     """Handle series streaming with episode range support"""
-    global selected_media, selected_subtitles
-    season = input("Enter season: ")
-    episode_input = input("Enter episode (e.g., '5' or '5-7' for range): ")
-    try:
-        season_num = int(season)
-    except ValueError:
-        print("Invalid season number")
-        raise RuntimeError("Invalid season number")
-    episode_numbers = parse_episode_range(episode_input)
-    if not episode_numbers:
-        raise RuntimeError("Invalid episode input")
-    media_id_match = re.search(r"/tv/[^/]*-(\d+)", get_id.selected_url)
+    if ctx.season is None:
+        ctx.season = typer.prompt("Enter season", type=int)
+    if ctx.episodes is None:
+        ctx.episodes = typer.prompt(
+            "Enter episode (e.g., '5' or '5-7' for range)", type=EpisodeRange.from_str
+        )
+
+    assert ctx.season is not None
+    assert ctx.episodes is not None
+    assert ctx.url is not None
+
+    media_id_match = re.search(r"/tv/[^/]*-(\d+)", ctx.url)
     if not media_id_match:
         raise RuntimeError("Could not extract media ID from URL")
+
     media_id = media_id_match.group(1)
-    seasons = get_tv_seasons(media_id)
+    seasons = get_tv_seasons(media_id, ctx.client)
     if not seasons:
         raise RuntimeError("Could not get seasons")
+
     target_season_id = None
     for season_data in seasons:
         season_title = season_data["title"].lower()
-        if f"season {season_num}" in season_title or f"s{season_num}" in season_title:
+        if f"season {ctx.season}" in season_title or f"s{ctx.season}" in season_title:
             target_season_id = season_data["id"]
             break
-    if not target_season_id and season_num <= len(seasons):
-        target_season_id = seasons[season_num - 1]["id"]
+
+    if not target_season_id and ctx.season <= len(seasons):
+        target_season_id = seasons[ctx.season - 1]["id"]
+
     if not target_season_id:
-        raise RuntimeError(f"Could not find season {season_num}")
-    episodes = get_season_episodes(target_season_id)
+        raise RuntimeError(f"Could not find season {ctx.season}")
+
+    episodes = get_season_episodes(target_season_id, ctx.client)
     if not episodes:
-        raise RuntimeError(f"Could not get episodes for season {season_num}")
+        raise RuntimeError(f"Could not get episodes for season {ctx.season}")
+
     max_episode = len(episodes)
-    for ep_num in episode_numbers:
+    for ep_num in ctx.episodes:
         if ep_num > max_episode:
-            raise RuntimeError(
-                f"Episode {ep_num} not found (only {max_episode} episodes available)"
-            )
+            err_msg = f"Episode {ep_num} not found (only {max_episode} episodes available)"
+            raise RuntimeError(err_msg)
+
     episode_data_list = []
     failed_episodes = []
-    for episode_num in episode_numbers:
+    for episode_num in ctx.episodes:
         target_episode = episodes[episode_num - 1]
-        episode_data = get_episode_data(target_episode, season_num, episode_num)
+        episode_data = get_episode_data(target_episode, ctx.season, episode_num, ctx.client)
         if episode_data:
             episode_data_list.append(episode_data)
         else:
             failed_episodes.append(episode_num)
-    if failed_episodes:
-        print(f"Warning: Failed to get data for episodes: {failed_episodes}")
+
     if not episode_data_list:
         raise RuntimeError("Could not get data for any episodes")
-    selected_media = episode_data_list
-    selected_subtitles = []
-    if len(episode_numbers) > 1:
+
+    if failed_episodes:
+        print(f"Warning: Failed to get data for episodes: {failed_episodes}")
+
+    ctx.selected_media = episode_data_list
+    ctx.selected_subtitles = []
+
+    if len(ctx.episodes) > 1:
         print(f"Successfully prepared {len(episode_data_list)} episodes for streaming/download")
     else:
-        print(f"Successfully prepared episode {episode_numbers[0]} for streaming/download")
+        print(f"Successfully prepared episode {ctx.episodes[0]} for streaming/download")
 
 
-def get_id(query: str):
+def get_id(ctx: Context) -> tuple[str, str, MediaType | None]:
     """Search and select content"""
-    selected_url = search_content(query)
-    if not selected_url:
-        print("No content selected")
-        exit(0)
-    get_id.selected_url = selected_url
+    assert ctx.query is not None
+    selected_url, title = search_content(ctx.query, ctx.client)
+
     if "/movie/" in selected_url:
-        get_id.content_type = "movie"
+        content_type = MediaType.MOVIE
     elif "/tv/" in selected_url:
-        get_id.content_type = "series"
+        content_type = MediaType.SERIES
     else:
-        get_id.content_type = "unknown"
-    return selected_url
+        content_type = None
+    return (selected_url, title, content_type)
 
 
-def poison():
+def get_content_type(ctx: Context):
     """Choose content type"""
-    if hasattr(get_id, "content_type") and get_id.content_type in ["movie", "series"]:
-        if get_id.content_type == "movie":
-            movie()
-        elif get_id.content_type == "series":
-            series()
-        else:
-            ch = fzf_prompt(["movie", "series"])
-            if ch == "movie":
-                movie()
-            elif ch == "series":
-                series()
-            else:
-                exit(0)
-    else:
-        ch = fzf_prompt(["movie", "series"])
-        if ch == "movie":
-            movie()
-        elif ch == "series":
-            series()
+    if ctx.content_type is None:
+        choice = fzf_prompt(["movie", "series"])
+        if choice == "movie":
+            return MediaType.MOVIE
+        elif choice == "series":
+            return MediaType.SERIES
         else:
             exit(0)
 
 
-def determine_path() -> str:
-    plt = platform.system()
-    if plt == "Windows":
-        return f"C://Users//{os.getenv('username')}//Downloads"
-    elif plt == "Linux" or plt == "FreeBSD":
-        return f"/home/{os.getlogin()}/Downloads"
-    elif plt == "Darwin":
-        return f"/Users/{os.getlogin()}/Downloads"
-    else:
-        print("[!] Make an issue for your OS.")
-        exit(0)
-
-
-def dlData(path: str = determine_path()):
+def dl_data(ctx: Context) -> None:
     """Download media with support for episode ranges"""
-    global selected_media
-    if selected_media:
+    if ctx.selected_media:
         episodes_to_download = (
-            selected_media if isinstance(selected_media, list) else [selected_media]
+            ctx.selected_media if isinstance(ctx.selected_media, list) else [ctx.selected_media]
         )
         print(f"Starting download of {len(episodes_to_download)} episode(s)...")
         for i, episode_data in enumerate(episodes_to_download, 1):
             print(f"\nDownloading episode {i}/{len(episodes_to_download)}: {episode_data['label']}")
             try:
                 decoded_url, subs = decrypt_stream_url(episode_data["file"])
+                subs = subs if subs else []
                 if "season" in episode_data and "episode" in episode_data:
                     episode_query = (
-                        f"{query}_S{episode_data['season']:02d}E{episode_data['episode']:02d}"
+                        f"{ctx.query}_S{episode_data['season']:02d}E{episode_data['episode']:02d}"
                     )
                 else:
-                    episode_query = f"{query}_Episode_{i}"
-                download(path, episode_query, decoded_url, FLIXHQ_BASE_URL, subs)
+                    episode_query = f"{ctx.query}_Episode_{i}"
+
+                if decoded_url is None:
+                    raise RuntimeError("unable to find url for episode")
+
+                download(ctx.dl_path, episode_query, decoded_url, FLIXHQ_BASE_URL, subs)
                 print(f"Successfully downloaded: {episode_data['label']}")
             except Exception as e:
                 print(f"Failed to download episode {i}: {e}")
@@ -387,16 +435,24 @@ def dlData(path: str = determine_path()):
         print("No media selected for download")
 
 
-def provideData(play_type: str) -> None:
+def provide_data(ctx: Context) -> None:
     """Play media with support for episode ranges"""
-    global selected_media, selected_subtitles
-    if selected_media:
-        episodes_to_play = selected_media if isinstance(selected_media, list) else [selected_media]
-        print(f"Starting playback of {len(episodes_to_play)} episode(s)...")
+    if ctx.selected_media:
+        episodes_to_play = (
+            ctx.selected_media if isinstance(ctx.selected_media, list) else [ctx.selected_media]
+        )
+        if ctx.content_type == MediaType.MOVIE:
+            print(f"Starting playback of {ctx.title}...")
+        else:
+            print(f"Starting playback of {len(episodes_to_play)} episode(s)...")
         for i, episode_data in enumerate(episodes_to_play, 1):
-            print(f"\nPlaying episode {i}/{len(episodes_to_play)}: {episode_data['label']}")
+            if ctx.content_type == MediaType.SERIES:
+                print(f"\nPlaying episode {i}/{len(episodes_to_play)}: {episode_data['label']}")
             try:
                 decoded_url, subs = decrypt_stream_url(episode_data["file"])
+                if decoded_url is None:
+                    raise RuntimeError(f"Failed to get url for episode {i}")
+                subs = subs if subs else []
 
                 if "episode_title" in episode_data:
                     episode_title = episode_data["episode_title"]
@@ -405,9 +461,9 @@ def provideData(play_type: str) -> None:
                 else:
                     episode_title = episode_data["label"]
 
-                if play_type == "play":
+                if ctx.play_type == "play":
                     play(decoded_url, episode_title, FLIXHQ_BASE_URL, subs)
-                elif play_type == "cast":
+                elif ctx.play_type == "cast":
                     cast(decoded_url, subs)
                 if len(episodes_to_play) > 1 and i < len(episodes_to_play):
                     continue_choice = input("\nContinue to next episode? (y/n): ").lower().strip()
@@ -427,26 +483,70 @@ def provideData(play_type: str) -> None:
         print("No media selected for playback")
 
 
-def init() -> None:
-    ch = fzf_prompt(["play", "download", "chromecaast", "exit"])
-    if ch == "play":
-        provideData("play")
-    elif ch == "download":
-        dlData()
-    elif ch == "chromecast":
-        provideData("cast")
+app = typer.Typer()
+
+
+# ruff: noqa: UP045 - allow using Optional[T] instead T | None
+# ruff: noqa: UP006 - allow using typing.List
+@app.command()
+def main(
+    query: Annotated[Optional[List[str]], typer.Argument(help="The name to search for")] = None,
+    action: Annotated[
+        Action,
+        typer.Option(
+            "--action",
+            "-a",
+            help="Type of playback",
+        ),
+    ] = Action.PLAY,
+    season: Annotated[
+        Optional[int], typer.Option("--season", "-s", help="Specify season number")
+    ] = None,
+    episodes: Annotated[
+        Optional[EpisodeRange],
+        typer.Option(
+            "--episodes",
+            "-e",
+            help="Specify episode/range of episodes to download",
+            parser=EpisodeRange.from_str,
+        ),
+    ] = None,
+):
+    headers = {
+        "User-Agent": f"flix-cli/{__core__}",
+        "Referer": "https://flixhq.to/",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    client = httpx.Client(headers=headers, follow_redirects=True, timeout=None)
+
+    ctx = Context(client=client)
+
+    if query is None:
+        ctx.query = typer.prompt("Search")
     else:
-        exit(0)
+        ctx.query = " ".join(query)
 
+    ctx.play_type = action
+    ctx.url, ctx.title, ctx.content_type = get_id(ctx)
 
-if len(sys.argv) == 1:
-    query = input("Search: ")
-    if query == "":
-        print("ValueError: no query parameter provided")
-        exit(0)
-else:
-    query = " ".join(sys.argv[1:])
+    if ctx.content_type is None:
+        get_content_type(ctx)
 
-get_id(query)
-poison()
-init()
+    if ctx.content_type == MediaType.MOVIE:
+        movie(ctx)
+    else:
+        if ctx.content_type != MediaType.SERIES:
+            if any((season, episodes)):
+                print("Warning: content type is not 'series', ignoring season/episode parameters")
+        else:
+            if episodes:
+                ctx.episodes = episodes
+            if season:
+                ctx.season = season
+
+        series(ctx)
+
+    if action in ("play", "cast"):
+        provide_data(ctx)
+    elif action == "download":
+        dl_data(ctx)

--- a/flix_cli/core/__flix_cli__.py
+++ b/flix_cli/core/__flix_cli__.py
@@ -466,15 +466,15 @@ def provide_data(ctx: Context) -> None:
                 elif ctx.play_type == "cast":
                     cast(decoded_url, subs)
                 if len(episodes_to_play) > 1 and i < len(episodes_to_play):
-                    continue_choice = input("\nContinue to next episode? (y/n): ").lower().strip()
-                    if continue_choice not in ["y", "yes", ""]:
+                    continue_choice = typer.confirm("Continue to next episode?")
+                    if not continue_choice:
                         print("Stopping playback")
                         break
             except Exception as e:
                 print(f"Failed to play episode {i}: {e}")
                 if len(episodes_to_play) > 1:
-                    continue_choice = input("\nSkip to next episode? (y/n): ").lower().strip()
-                    if continue_choice not in ["y", "yes", ""]:
+                    continue_choice = typer.confirm("Continue to next episode?")
+                    if not continue_choice:
                         print("Stopping playback")
                         break
                 else:

--- a/flix_cli/core/utils/__decryptor__.py
+++ b/flix_cli/core/utils/__decryptor__.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import sys
 
@@ -11,11 +10,12 @@ client = httpx.Client(headers=headers, follow_redirects=True, timeout=None)
 
 API_URL = "https://dec.eatmynerds.live"
 
-def decrypt_stream_url(embed_link, quality=None, subs_language="english"):
-    params = {
-        "url": embed_link
-    }
-    
+
+def decrypt_stream_url(
+    embed_link, quality=None, subs_language="english"
+) -> tuple[str | None, list[str] | None]:
+    params = {"url": embed_link}
+
     response = client.get(API_URL, params=params)
 
     if response.status_code != 200:

--- a/flix_cli/core/utils/__downloader__.py
+++ b/flix_cli/core/utils/__downloader__.py
@@ -1,5 +1,5 @@
-import os
 import subprocess
+from pathlib import Path
 
 import httpx
 
@@ -12,20 +12,21 @@ FLIX_CLI_DOWNLOADS = "flix-cli"
 client = httpx.Client(timeout=None)
 
 
-def download(path: str, name: str, file: str, referer: str, subs: list[str]) -> None:
+def download(path: Path, name: str, file: str, referer: str, subs: list[str]) -> None:
     _, dl_path = get_config()
+    dl_path = Path(dl_path)
 
     name = name.replace(" ", "-")
     name = name.replace('"', "")
     url = file
 
-    if os.path.exists(dl_path):
+    if dl_path.exists():
         path = dl_path
 
-    if not os.path.exists(f"{path}/{FLIX_CLI_DOWNLOADS}"):
-        os.makedirs(f"{path}/{FLIX_CLI_DOWNLOADS}")
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
 
-    path = f"{path}/{FLIX_CLI_DOWNLOADS}"
+    path /= FLIX_CLI_DOWNLOADS
 
     args = [
         YT_DLP_EXECUTABLE,

--- a/flix_cli/core/utils/__player__.py
+++ b/flix_cli/core/utils/__player__.py
@@ -41,7 +41,9 @@ def play(file: str, name: str, referer: str, subtitles: list[str]) -> None:
                 ]
                 args.extend(f"--sub-file={_}" for _ in subtitles)
 
-                mpv_process = subprocess.Popen(args, stdout=subprocess.DEVNULL)
+                mpv_process = subprocess.Popen(
+                    args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                )
                 mpv_process.wait()
 
             """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.8.1"
 description = "A high efficient, powerful and fast movie scraper."
 authors = [{name = "DemonKingSwarn", email = "rockingswarn@gmail.com"}]
 license = {text = "GPLv3"}
-readme = "readme.txt"
+readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "beautifulsoup4==4.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,20 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flix-cli"
-version = "1.8.0"
+version = "1.8.1"
 description = "A high efficient, powerful and fast movie scraper."
 authors = [{name = "DemonKingSwarn", email = "rockingswarn@gmail.com"}]
 license = {text = "GPLv3"}
 readme = "readme.txt"
 requires-python = ">=3.11"
 dependencies = [
-    "httpx==0.28.1",
     "beautifulsoup4==4.10.0",
-    "regex==2025.9.1",
-    "krfzf-py==0.0.4",
     "catt==0.13.1",
+    "httpx==0.28.1",
+    "krfzf-py==0.0.4",
+    "platformdirs==4.5.0",
+    "regex==2025.9.1",
+    "typer==0.20.0",
     "yt-dlp>=2025.10.22",
 ]
 
@@ -23,7 +25,7 @@ dependencies = [
 dev = []
 
 [project.scripts]
-flix-cli = "flix_cli.__main__:__flixcli__"
+flix-cli = "flix_cli.core.__flix_cli__:app"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -161,14 +161,16 @@ wheels = [
 
 [[package]]
 name = "flix-cli"
-version = "1.7.11.6"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "catt" },
     { name = "httpx" },
     { name = "krfzf-py" },
+    { name = "platformdirs" },
     { name = "regex" },
+    { name = "typer" },
     { name = "yt-dlp" },
 ]
 
@@ -183,7 +185,9 @@ requires-dist = [
     { name = "catt", specifier = "==0.13.1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "krfzf-py", specifier = "==0.0.4" },
+    { name = "platformdirs", specifier = "==4.5.0" },
     { name = "regex", specifier = "==2025.9.1" },
+    { name = "typer", specifier = "==0.20.0" },
     { name = "yt-dlp", specifier = ">=2025.10.22" },
 ]
 provides-extras = ["dev"]
@@ -256,6 +260,36 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -282,6 +316,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0d/8d/8ff8f1e114dcf8f7ed00e4d1472b5b6c2dc1c895cadadd7942ea1ec6ddd6/pychromecast-14.0.9.tar.gz", hash = "sha256:fe78841b0b04aa107d08aed216e91ab9cfb54b11d089d382be4e987e3631d4a6", size = 61484, upload-time = "2025-08-20T11:03:07.392Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/28/bdcde91d9644ea7d358cd5ff0ff95e9528ef1ee86eaa9e89b312bff74173/pychromecast-14.0.9-py2.py3-none-any.whl", hash = "sha256:77955c622a002f25e44a17536bd08916a7515d7f9c0878f1f94cac97af1c2a55", size = 77368, upload-time = "2025-08-20T11:03:06.285Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -364,6 +407,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +446,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -405,6 +470,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refactored CLI to use typer and other misc related changes (refactoring of types/cleaning up a few functions)

added dependencies:
- platformdirs - just works™, no need to worry about platform dependent paths for downloads, also handles cases where home directory is not `/home/username` and similar edge cases
- typer - for cli handling, arguably can be done with argparse, but it is just simpler/easier and you get help menu and shell completions for free